### PR TITLE
Enhance layout and loading feedback

### DIFF
--- a/core/chart_card.py
+++ b/core/chart_card.py
@@ -13,7 +13,11 @@ from services import (
     band_from_moving_stats,
     detect_linear_anomalies,
 )
-from core.plot_utils import add_latest_labels_no_overlap, apply_elegant_theme
+from core.plot_utils import (
+    add_latest_labels_no_overlap,
+    apply_elegant_theme,
+    render_plotly_with_spinner,
+)
 
 UNIT_SCALE = {"円": 1, "千円": 1_000, "百万円": 1_000_000}
 MAX_DISPLAY_PRODUCTS = 60
@@ -767,7 +771,7 @@ def build_chart_card(
     }
     if config:
         base_config.update(config)
-    st.plotly_chart(
+    render_plotly_with_spinner(
         fig,
         use_container_width=True,
         height=plot_height,

--- a/core/plot_utils.py
+++ b/core/plot_utils.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pandas as pd
 import numpy as np
 import plotly.graph_objects as go
@@ -144,4 +146,26 @@ def add_latest_labels_no_overlap(
             bgcolor="rgba(0,0,0,0)",
             bordercolor="rgba(0,0,0,0)",
             font=dict(size=font_size),
+        )
+
+
+def render_plotly_with_spinner(
+    fig: go.Figure,
+    *,
+    spinner_text: str = "グラフを描画中…",
+    use_container_width: bool = True,
+    config: dict | None = None,
+    **kwargs: Any,
+) -> None:
+    """Render a Plotly figure with a spinner to highlight processing."""
+
+    with st.spinner(spinner_text):
+        height = kwargs.pop("height", None)
+        if height is not None:
+            fig.update_layout(height=height)
+        st.plotly_chart(
+            fig,
+            use_container_width=use_container_width,
+            config=config,
+            **kwargs,
         )


### PR DESCRIPTION
## Summary
- align the page configuration and styling with a wide layout, Japanese Google Fonts, and hierarchical typography for clearer emphasis
- add spinners around file ingestion and plot rendering via a shared helper so heavy operations communicate progress to the user
- fold AI-driven insights into expanders so optional guidance stays hidden until needed

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc1d194e088323b2ef8a1fcaa25b92