### PR TITLE
Add SKU-level correlation analysis

### DIFF
--- a/services.py
+++ b/services.py
@@ -555,6 +555,95 @@ def get_yearly_series(df_year: pd.DataFrame,
     return df, pivot
 
 
+def sku_correlation_pivot(df_year: pd.DataFrame,
+                          codes: Optional[List[str]] = None,
+                          start: Optional[str] = None,
+                          end: Optional[str] = None,
+                          metric: str = "year_sum") -> pd.DataFrame:
+    """年計ロングデータからSKU相関分析向けのピボットを構築する。
+
+    行を月、列をSKUコード（product_code）とし、指定された指標の値を格納する。
+
+    Parameters
+    ----------
+    df_year : pd.DataFrame
+        年計ロングデータ。
+    codes : list[str], optional
+        対象SKUコード。None の場合は全SKU。
+    start, end : str, optional
+        分析対象期間 (YYYY-MM)。
+    metric : str
+        取り出す指標列。既定は year_sum。
+
+    Returns
+    -------
+    pd.DataFrame
+        index=month, columns=product_code のワイド表。昇順にソート済み。
+    """
+
+    _, pivot = get_yearly_series(
+        df_year,
+        codes=codes,
+        start=start,
+        end=end,
+        metric=metric,
+    )
+    return pivot.sort_index()
+
+
+def pairwise_correlation(pivot: pd.DataFrame, method: str = "pearson") -> pd.DataFrame:
+    """列（SKU）同士の相関を計算する。
+
+    Parameters
+    ----------
+    pivot : pd.DataFrame
+        行=観測（月）、列=SKUの数値データ。
+    method : str
+        pandas.DataFrame.corr に準じた相関手法。'pearson' または 'spearman'。
+
+    Returns
+    -------
+    pd.DataFrame
+        pair: "SKUa×SKUb" 形式のペア識別子
+        code_a, code_b: SKUコード
+        r: 相関係数
+        n: 相関算出に使用したサンプル数（月数）
+
+    Notes
+    -----
+    NaN を含む観測は各ペアごとに除外し、両変数とも変動がある場合のみ計算する。
+    """
+
+    cols = list(pivot.columns)
+    rows = []
+    for i, a in enumerate(cols):
+        for b in cols[i + 1 :]:
+            sub = pivot[[a, b]].dropna()
+            n = len(sub)
+            if n < 2:
+                continue
+            if sub[a].nunique() < 2 or sub[b].nunique() < 2:
+                continue
+            r = sub[a].corr(sub[b], method=method)
+            if pd.isna(r):
+                continue
+            rows.append(
+                {
+                    "pair": f"{a}×{b}",
+                    "code_a": a,
+                    "code_b": b,
+                    "r": float(r),
+                    "n": int(n),
+                }
+            )
+    if not rows:
+        return pd.DataFrame(columns=["pair", "code_a", "code_b", "r", "n"])
+    out = pd.DataFrame(rows)
+    out["abs_r"] = out["r"].abs()
+    out = out.sort_values("abs_r", ascending=False, ignore_index=True)
+    return out.drop(columns="abs_r")
+
+
 def top_growth_codes(df_year: pd.DataFrame, end_month: str, window: int = 6, top: int = 10) -> List[str]:
     """直近windowカ月の伸長上位商品コードを返す。"""
     if df_year.empty:

--- a/tests/test_sku_corr.py
+++ b/tests/test_sku_corr.py
@@ -1,0 +1,55 @@
+import pandas as pd
+import pytest
+
+from services import sku_correlation_pivot, pairwise_correlation
+
+
+def _sample_year_df():
+    data = [
+        ("A", "Alpha", "2023-01", 10.0),
+        ("A", "Alpha", "2023-02", 20.0),
+        ("A", "Alpha", "2023-03", 30.0),
+        ("B", "Beta", "2023-01", 30.0),
+        ("B", "Beta", "2023-02", 20.0),
+        ("B", "Beta", "2023-03", 10.0),
+        ("C", "Gamma", "2023-01", 5.0),
+        ("C", "Gamma", "2023-02", 15.0),
+        ("C", "Gamma", "2023-03", 25.0),
+    ]
+    return pd.DataFrame(
+        data,
+        columns=["product_code", "product_name", "month", "year_sum"],
+    )
+
+
+def test_pairwise_correlation_basic():
+    df_year = _sample_year_df()
+    pivot = sku_correlation_pivot(df_year)
+    result = pairwise_correlation(pivot, method="pearson")
+    pairs = {row.pair: row for row in result.itertuples()}
+
+    assert pytest.approx(pairs["A×B"].r, abs=1e-6) == -1.0
+    assert pytest.approx(pairs["A×B"].n) == 3
+    assert pytest.approx(pairs["A×C"].r, abs=1e-6) == 1.0
+    assert pytest.approx(pairs["B×C"].r, abs=1e-6) == -1.0
+    assert pairs["B×C"].n == 3
+
+
+def test_pairwise_correlation_respects_period_filter():
+    df_year = _sample_year_df()
+    pivot = sku_correlation_pivot(df_year, start="2023-02", end="2023-03")
+    result = pairwise_correlation(pivot, method="pearson")
+    pairs = {row.pair: row for row in result.itertuples()}
+
+    # 2ヶ月のみを対象とするためサンプル数は2
+    assert pairs["A×B"].n == 2
+    assert pytest.approx(pairs["A×B"].r, abs=1e-6) == -1.0
+
+
+def test_pairwise_correlation_skips_constant_series():
+    df_year = _sample_year_df()
+    # SKU C は一定値のため、他SKUとの相関結果から除外される
+    df_year.loc[df_year["product_code"] == "C", "year_sum"] = 5.0
+    pivot = sku_correlation_pivot(df_year)
+    filtered = pairwise_correlation(pivot[["A", "C"]], method="pearson")
+    assert filtered.empty


### PR DESCRIPTION
## Summary
- add a SKU correlation tab with selection controls, heatmaps, and pair explorer in the correlation view
- provide service utilities to build SKU correlation pivots and pairwise coefficients
- cover the correlation utilities with unit tests

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd6142753083238b05a8949e8e6b19