### PR TITLE
Fix tour highlight script syntax

### DIFF
--- a/app.py
+++ b/app.py
@@ -666,7 +666,7 @@ def apply_tour_highlight(step: Optional[Dict[str, str]]) -> None:
 
         const hints = Array.from(doc.querySelectorAll('div, span')).filter((el) => normalize(el.textContent).includes('→キーで次へ'));
         hints.forEach((el) => el.remove());
-    };
+    }};
     setTimeout(run, 120);
     </script>
     """


### PR DESCRIPTION
## Summary
- escape the closing brace in the tour highlight script f-string to prevent a syntax error at import time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceca977b4483238de5cc4dea4c209b