### PR TITLE
Add language selector and i18n helpers

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,13 @@ from ai_features import (
     answer_question,
     generate_anomaly_brief,
 )
+from core.i18n import (
+    get_available_languages,
+    get_current_language,
+    init_language,
+    language_name,
+    t,
+)
 
 # McKinsey inspired pastel palette
 MCKINSEY_PALETTE = [
@@ -31,6 +38,9 @@ MCKINSEY_PALETTE = [
 ]
 # Apply palette across figures
 px.defaults.color_discrete_sequence = MCKINSEY_PALETTE
+
+init_language()
+current_language = get_current_language()
 
 PLOTLY_CONFIG = {
     "locale": "ja",
@@ -49,8 +59,9 @@ PLOTLY_CONFIG = {
     ],
     "toImageButtonOptions": {"format": "png", "filename": "年計比較"},
 }
+PLOTLY_CONFIG["locale"] = "ja" if current_language == "ja" else "en"
 
-APP_TITLE = "売上年計（12カ月移動累計）ダッシュボード"
+APP_TITLE = t("header.title", language=current_language)
 st.set_page_config(
     page_title=APP_TITLE, layout="wide", initial_sidebar_state="expanded"
 )
@@ -422,13 +433,36 @@ section[data-testid="stSidebar"] label.tour-highlight-nav *{
     unsafe_allow_html=True,
 )
 
-# ===== Elegant（品格）UI ON/OFF（ヘッダに設置） =====
-elegant_on = st.toggle(
-    "品格UI",
-    value=True,
-    help="上品で読みやすい配色・余白・タイポグラフィを適用",
-)
-st.session_state["elegant_on"] = elegant_on
+# ===== Elegant（品格）UI ON/OFF & Language Selector =====
+if "elegant_on" not in st.session_state:
+    st.session_state["elegant_on"] = True
+
+with st.container():
+    control_left, control_right = st.columns([3, 1])
+    with control_left:
+        elegant_on = st.toggle(
+            t("header.elegant_toggle.label"),
+            value=st.session_state.get("elegant_on", True),
+            help=t("header.elegant_toggle.help"),
+            key="elegant_ui_toggle",
+        )
+        st.session_state["elegant_on"] = elegant_on
+    with control_right:
+        language_codes = get_available_languages()
+        if language_codes:
+            current_value = st.session_state.get("language")
+            if current_value not in language_codes:
+                st.session_state["language"] = language_codes[0]
+        else:
+            language_codes = [get_current_language()]
+        st.selectbox(
+            t("header.language_selector.label"),
+            options=language_codes,
+            key="language",
+            format_func=lambda code: language_name(code),
+        )
+
+elegant_on = st.session_state.get("elegant_on", True)
 
 # ===== 品格UI CSS（配色/余白/フォント/境界の見直し） =====
 if elegant_on:
@@ -522,9 +556,9 @@ def render_app_hero():
     st.markdown(
         f"""
         <div class=\"mck-hero\">
-            <div class=\"mck-hero__eyebrow\">Growth Intelligence Workspace</div>
-            <h1>{APP_TITLE}</h1>
-            <p>12カ月移動累計で成長ドライバーとリスクを直感的に把握し、次の一手を素早く導きます。</p>
+            <div class=\"mck-hero__eyebrow\">{t("header.eyebrow")}</div>
+            <h1>{t("header.title")}</h1>
+            <p>{t("header.description")}</p>
         </div>
         """,
         unsafe_allow_html=True,
@@ -1003,7 +1037,7 @@ st.sidebar.markdown(
     """,
     unsafe_allow_html=True,
 )
-st.sidebar.title("ナビゲーション")
+st.sidebar.title(t("sidebar.navigation_title"))
 
 SIDEBAR_PAGES = [
     ("🏠 ホーム", "ダッシュボード"),

--- a/core/i18n.py
+++ b/core/i18n.py
@@ -1,0 +1,108 @@
+"""Internationalization helpers for the Streamlit app."""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+import streamlit as st
+import yaml
+
+DEFAULT_LANGUAGE = "ja"
+_TRANSLATION_FILE = Path(__file__).with_name("translations.yaml")
+
+
+@lru_cache()
+def _load_translations() -> Dict[str, Any]:
+    """Load the translation dictionary from the YAML file."""
+    if not _TRANSLATION_FILE.exists():
+        return {}
+    with _TRANSLATION_FILE.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _resolve_key(key: str) -> Any:
+    """Resolve a dotted key path inside the translation dictionary."""
+    data = _load_translations()
+    node: Any = data
+    for part in key.split("."):
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        else:
+            return None
+    return node
+
+
+def init_language(default: str = DEFAULT_LANGUAGE) -> str:
+    """Ensure the session state has a language value."""
+    available = get_available_languages()
+    if default not in available and available:
+        default = available[0]
+    if "language" not in st.session_state:
+        st.session_state["language"] = default
+    return st.session_state["language"]
+
+
+def get_current_language() -> str:
+    """Return the current language stored in the session state."""
+    lang = st.session_state.get("language", DEFAULT_LANGUAGE)
+    available = get_available_languages()
+    if available and lang not in available:
+        return available[0]
+    return lang
+
+
+def get_available_languages() -> List[str]:
+    """Return the supported language codes defined in the translation file."""
+    data = _load_translations()
+    languages = data.get("languages")
+    if isinstance(languages, list):
+        return [str(code) for code in languages if code]
+    if isinstance(languages, dict):
+        return [str(code) for code in languages.keys()]
+    language_names = data.get("language_names")
+    if isinstance(language_names, dict):
+        return [str(code) for code in language_names.keys()]
+    return [DEFAULT_LANGUAGE]
+
+
+def translate(key: str, *, language: str | None = None, default: str | None = None) -> str:
+    """Fetch a translated string.
+
+    Parameters
+    ----------
+    key:
+        Dotted path identifying the entry in the translation dictionary.
+    language:
+        Override language code. When ``None`` the session state's language is used.
+    default:
+        Fallback text when the key or translation is missing. If omitted, the
+        key itself is returned.
+    """
+
+    lang = language or get_current_language()
+    node = _resolve_key(key)
+    if node is None:
+        return default if default is not None else key
+    if isinstance(node, dict):
+        if lang in node and node[lang] is not None:
+            return str(node[lang])
+        if DEFAULT_LANGUAGE in node and node[DEFAULT_LANGUAGE] is not None:
+            return str(node[DEFAULT_LANGUAGE])
+        for value in node.values():
+            if isinstance(value, str):
+                return value
+        return default if default is not None else key
+    return str(node)
+
+
+def language_name(code: str, *, language: str | None = None) -> str:
+    """Return the localized display name for a language code."""
+    return translate(f"language_names.{code}", language=language, default=code)
+
+
+# Shorthand alias used in the app.
+t = translate

--- a/core/translations.yaml
+++ b/core/translations.yaml
@@ -1,0 +1,38 @@
+languages:
+  - ja
+  - en
+
+language_names:
+  ja:
+    ja: 日本語
+    en: Japanese
+  en:
+    ja: 英語
+    en: English
+
+header:
+  title:
+    ja: "売上年計（12カ月移動累計）ダッシュボード"
+    en: "Rolling 12-Month Total Sales Dashboard"
+  eyebrow:
+    ja: "グロースインテリジェンス・ワークスペース"
+    en: "Growth Intelligence Workspace"
+  description:
+    ja: "12カ月移動累計で成長ドライバーとリスクを直感的に把握し、次の一手を素早く導きます。"
+    en: "Understand growth drivers and risks through a rolling 12-month view and decide the next action quickly."
+  elegant_toggle:
+    label:
+      ja: "品格UI"
+      en: "Elegant UI"
+    help:
+      ja: "上品で読みやすい配色・余白・タイポグラフィを適用"
+      en: "Apply refined colors, spacing, and typography for a polished reading experience."
+  language_selector:
+    label:
+      ja: "言語"
+      en: "Language"
+
+sidebar:
+  navigation_title:
+    ja: "ナビゲーション"
+    en: "Navigation"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ scikit-learn
 networkx
 python-louvain
 chardet
+PyYAML
 ruff
 black
 pytest


### PR DESCRIPTION
## Summary
- add an i18n helper module and YAML translation dictionary for Japanese and English copy
- initialize the Streamlit session state's language and expose a header selector alongside localized hero/sidebar text
- update dependencies to include PyYAML for loading the translation resources

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cece921e088323bb4b167d7df3a245