### PR TITLE
Add instant sample data loader

### DIFF
--- a/sample_data/__init__.py
+++ b/sample_data/__init__.py
@@ -1,0 +1,160 @@
+"""Utility helpers for generating the built-in demo dataset."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+__all__ = ["load_sample_dataset"]
+
+
+@dataclass(frozen=True)
+class _ProductTemplate:
+    code: str
+    name: str
+    base: float
+    trend: float
+    seasonality: float
+    volatility: float
+    phase: float = 0.0
+    promo_every: int | None = None
+    promo_lift: float = 1.0
+    promo_offset: int = 0
+    dip_month: str | None = None
+    dip_scale: float = 1.0
+
+
+def _simulate_products(months: Iterable[pd.Period]) -> pd.DataFrame:
+    rng = np.random.default_rng(20240115)
+    templates = [
+        _ProductTemplate(
+            code="SMP001",
+            name="サンプル栄養ドリンクA",
+            base=3_800_000,
+            trend=0.010,
+            seasonality=0.12,
+            volatility=0.05,
+        ),
+        _ProductTemplate(
+            code="SMP002",
+            name="サンプル炭酸飲料B",
+            base=2_900_000,
+            trend=0.007,
+            seasonality=0.18,
+            volatility=0.06,
+            phase=1.2,
+        ),
+        _ProductTemplate(
+            code="SMP003",
+            name="サンプルスナックC",
+            base=2_100_000,
+            trend=0.004,
+            seasonality=0.08,
+            volatility=0.05,
+            phase=2.2,
+        ),
+        _ProductTemplate(
+            code="SMP004",
+            name="サンプル健康食品D",
+            base=4_600_000,
+            trend=0.016,
+            seasonality=0.05,
+            volatility=0.04,
+            promo_every=6,
+            promo_lift=1.18,
+            promo_offset=2,
+        ),
+        _ProductTemplate(
+            code="SMP005",
+            name="サンプル冷凍食品E",
+            base=3_000_000,
+            trend=-0.003,
+            seasonality=0.10,
+            volatility=0.05,
+            phase=0.8,
+            dip_month="2023-08",
+            dip_scale=0.65,
+        ),
+        _ProductTemplate(
+            code="SMP006",
+            name="サンプルコスメF",
+            base=2_700_000,
+            trend=0.020,
+            seasonality=0.04,
+            volatility=0.07,
+            phase=3.1,
+            promo_every=12,
+            promo_lift=1.30,
+        ),
+        _ProductTemplate(
+            code="SMP007",
+            name="サンプル家電G",
+            base=5_500_000,
+            trend=0.008,
+            seasonality=0.25,
+            volatility=0.09,
+            phase=1.6,
+            promo_every=12,
+            promo_lift=1.40,
+            promo_offset=5,
+        ),
+        _ProductTemplate(
+            code="SMP008",
+            name="サンプルデジタルH",
+            base=1_900_000,
+            trend=0.013,
+            seasonality=0.06,
+            volatility=0.05,
+            phase=2.8,
+        ),
+    ]
+
+    records: list[dict[str, object]] = []
+    two_pi = 2.0 * np.pi
+    for idx, period in enumerate(months):
+        month_str = period.strftime("%Y-%m")
+        rotation = two_pi * (idx % 12) / 12.0
+        for template in templates:
+            base_level = template.base * ((1 + template.trend) ** idx)
+            seasonal = 1 + template.seasonality * np.sin(rotation + template.phase)
+            noise = 1 + rng.normal(0.0, template.volatility)
+            estimate = base_level * seasonal * max(noise, 0.55)
+
+            if template.promo_every and (
+                (idx - template.promo_offset) % template.promo_every == 0
+            ):
+                estimate *= template.promo_lift
+
+            if template.dip_month and month_str == template.dip_month:
+                estimate *= template.dip_scale
+
+            amount = float(max(0.0, estimate))
+            records.append(
+                {
+                    "product_code": template.code,
+                    "product_name": template.name,
+                    "month": month_str,
+                    "sales_amount_jpy": amount,
+                    "is_missing": False,
+                }
+            )
+
+    df = pd.DataFrame.from_records(records)
+    df["sales_amount_jpy"] = df["sales_amount_jpy"].round(0)
+    df["product_code"] = df["product_code"].astype(str)
+    df["product_name"] = df["product_name"].astype(str)
+    df["month"] = df["month"].astype(str)
+    df["is_missing"] = df["is_missing"].astype(bool)
+    return df
+
+
+def load_sample_dataset() -> pd.DataFrame:
+    """Return a synthetic long-form dataset for instant demos."""
+
+    months = pd.period_range("2022-01", periods=30, freq="M")
+    sample_df = _simulate_products(months)
+    sample_df = sample_df.sort_values(["product_code", "month"], ignore_index=True)
+    return sample_df

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from sample_data import load_sample_dataset
+from services import fill_missing_months, compute_year_rolling, compute_slopes
+
+
+def test_sample_dataset_structure():
+    df = load_sample_dataset()
+    required_cols = {"product_code", "product_name", "month", "sales_amount_jpy", "is_missing"}
+    assert required_cols.issubset(df.columns)
+    assert df["product_code"].nunique() >= 5
+    assert df["month"].nunique() >= 12
+    assert (df["sales_amount_jpy"] >= 0).all()
+    assert df["is_missing"].dtype == bool
+
+
+def test_sample_dataset_pipeline_roundtrip():
+    df = load_sample_dataset()
+    filled = fill_missing_months(df, policy="zero_fill")
+    year_df = compute_year_rolling(filled, window=12, policy="zero_fill")
+    year_df = compute_slopes(year_df, last_n=12)
+
+    assert not year_df.empty
+    assert year_df["year_sum"].notna().any()
+    assert not year_df["product_code"].isna().any()
+    # Ensure chronological order per product
+    grouped = year_df.groupby("product_code")
+    for _, group in grouped:
+        months = pd.to_datetime(group["month"]).sort_values()
+        assert months.is_monotonic_increasing


### PR DESCRIPTION
## Summary
- add a synthetic multi-month sample dataset so the dashboard can be explored without an upload
- surface a "サンプルデータを表示する" button and success toast when no data is loaded, wiring the generated data into session state
- cover the loader with tests to ensure the sample data flows through the existing aggregation pipeline

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d242f30d108323b6306869d7c2dda0