### PR TITLE
Add upload data quality checks

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import html
 import io
 import json
 import math
+from collections import Counter
 import re
 import textwrap
 from datetime import datetime
@@ -670,6 +671,7 @@ def _ai_anomaly_report(df: pd.DataFrame) -> str:
 
 
 from services import (
+    DataQualityIssue,
     parse_uploaded_table,
     fill_missing_months,
     compute_year_rolling,
@@ -688,6 +690,7 @@ from services import (
     slopes_snapshot,
     shape_flags,
     detect_linear_anomalies,
+    detect_data_quality_issues,
 )
 from sample_data import load_sample_dataset
 from core.chart_card import toolbar_sku_detail, build_chart_card
@@ -2977,8 +2980,84 @@ if page == "データ取込":
             summary_rows.append({"必要項目": field["label"], "割当列": display_value})
 
         st.table(pd.DataFrame(summary_rows))
+
+        quality_issues: List[DataQualityIssue] = []
+
         if missing_required:
             st.warning("未割当の必須項目があります: " + ", ".join(missing_required))
+            st.info("必須項目の割当後にデータ品質チェックが実行されます。")
+        else:
+            st.subheader("データ品質チェック")
+            quality_issues = detect_data_quality_issues(df_raw, column_mapping)
+            if quality_issues:
+                st.warning(
+                    f"{len(quality_issues)} 件の修正候補が見つかりました。CSVの該当行を確認してください。"
+                )
+
+                issue_type_labels = {
+                    "missing_month": "欠損値",
+                    "invalid_month": "形式エラー",
+                    "missing_product_name": "欠損値",
+                    "missing_channel": "欠損値",
+                    "missing_sales": "欠損値",
+                    "non_numeric_sales": "形式エラー",
+                    "negative_sales": "異常値",
+                }
+
+                def _format_value(value: object) -> str:
+                    if value is None:
+                        return ""
+                    if isinstance(value, (float, np.floating)):
+                        if np.isnan(value):
+                            return ""
+                        text = f"{float(value):,.2f}"
+                        return text.rstrip("0").rstrip(".")
+                    if isinstance(value, (int, np.integer)):
+                        return f"{int(value):,}"
+                    return str(value)
+
+                issue_rows = []
+                for issue in quality_issues:
+                    type_label = issue_type_labels.get(issue.issue_type, issue.issue_type)
+                    issue_rows.append(
+                        {
+                            "CSV行": issue.row_number,
+                            "列": issue.column,
+                            "種別": type_label,
+                            "エラー内容": issue.message,
+                            "推奨対応": issue.suggestion,
+                            "候補値": _format_value(issue.suggested_value),
+                            "元の値": _format_value(issue.original_value),
+                        }
+                    )
+
+                issue_df = pd.DataFrame(issue_rows)
+                issue_df = issue_df.sort_values(["CSV行", "列", "種別"], ignore_index=True)
+                max_display = 200
+                display_df = issue_df.head(max_display)
+                base_height = 64
+                row_height = 28
+                height = base_height + len(display_df) * row_height
+                height = max(160, min(520, height))
+                st.dataframe(display_df, use_container_width=True, height=height)
+                if len(issue_df) > max_display:
+                    st.caption(
+                        (
+                            f"先頭 {max_display} 件を表示しています。"
+                            f"残り {len(issue_df) - max_display} 件はファイル側で修正してください。"
+                        )
+                    )
+
+                type_counts = Counter(issue.issue_type for issue in quality_issues)
+                if type_counts:
+                    summary_parts = []
+                    for issue_type, count in type_counts.most_common():
+                        label = issue_type_labels.get(issue_type, issue_type)
+                        summary_parts.append(f"{label}: {count}件")
+                    st.caption("種別内訳: " + " / ".join(summary_parts))
+                st.caption("CSV行番号はヘッダー行を1としてカウントしています。")
+            else:
+                st.success("重大なデータ品質の問題は見つかりませんでした。")
 
         convert_disabled = bool(missing_required)
         convert_help = (
@@ -3014,7 +3093,16 @@ if page == "データ取込":
                     "取込完了。ダッシュボードへ移動して可視化を確認してください。"
                 )
 
-                st.subheader("品質チェック（欠測月/非数値/重複）")
+                st.subheader("データ品質サマリー")
+                if quality_issues:
+                    st.warning(
+                        (
+                            f"データ品質チェックで {len(quality_issues)} 件の確認事項が見つかりました。"
+                            "CSVを修正して再取込すると分析精度が向上します。"
+                        )
+                    )
+                else:
+                    st.info("データ品質チェックで重大な問題は見つかりませんでした。")
                 # 欠測月
                 miss_rate = (long_df["is_missing"].sum(), len(long_df))
                 st.write(f"- 欠測セル数: {miss_rate[0]:,} / {miss_rate[1]:,}")

--- a/services.py
+++ b/services.py
@@ -17,6 +17,17 @@ class FactRecord:
     is_missing: bool = False
 
 
+@dataclass
+class DataQualityIssue:
+    row_number: int
+    column: str
+    issue_type: str
+    message: str
+    suggestion: str
+    suggested_value: Optional[object] = None
+    original_value: Optional[object] = None
+
+
 # ---------- Utilities ----------
 def normalize_month_key(value: str) -> str:
     """Normalize a variety of month formats to 'YYYY-MM'."""
@@ -53,6 +64,192 @@ def month_range(min_m: str, max_m: str) -> List[str]:
         out.append(cur.strftime("%Y-%m"))
         cur += relativedelta(months=1)
     return out
+
+
+def detect_data_quality_issues(
+    df: pd.DataFrame,
+    mapping: Dict[str, Optional[str]],
+    *,
+    header_offset: int = 2,
+) -> List[DataQualityIssue]:
+    """Return potential data quality issues for the mapped upload table.
+
+    Parameters
+    ----------
+    df:
+        Raw dataframe as uploaded by the user.
+    mapping:
+        Column mapping dictionary (same keys as parse_uploaded_table).
+    header_offset:
+        Offset applied to the dataframe index to approximate the CSV row number.
+        Defaults to 2 (1 header row + 1-based index).
+    """
+
+    required_keys = {"month", "product_name", "sales"}
+    mapped_columns = {key: mapping.get(key) for key in mapping if mapping.get(key)}
+    if not required_keys.issubset(mapped_columns.keys()):
+        # Cannot evaluate quality until required columns are mapped
+        return []
+
+    for field, column in mapped_columns.items():
+        if column not in df.columns:
+            raise ValueError(f"列 '{column}' がファイル内に見つかりません。")
+
+    month_col = mapping["month"]
+    product_col = mapping["product_name"]
+    sales_col = mapping["sales"]
+    channel_col = mapping.get("channel") if mapping.get("channel") in df.columns else None
+
+    issues: List[DataQualityIssue] = []
+
+    def _is_blank(value: object) -> bool:
+        if pd.isna(value):
+            return True
+        if isinstance(value, str) and value.strip() == "":
+            return True
+        return False
+
+    def _coerce_numeric(value: object) -> float:
+        try:
+            num = pd.to_numeric(pd.Series([value]), errors="coerce").iloc[0]
+        except Exception:
+            num = np.nan
+        return float(num) if not pd.isna(num) else np.nan
+
+    selected_cols = [month_col, product_col, sales_col]
+    if channel_col:
+        selected_cols.append(channel_col)
+
+    subset = df[selected_cols]
+
+    for display_idx, row in enumerate(subset.itertuples(index=True, name=None)):
+        row_index = row[0]
+        values = row[1:]
+        value_map = dict(zip(selected_cols, values))
+
+        if isinstance(row_index, (int, np.integer)):
+            row_number = int(row_index) + header_offset
+        elif isinstance(row_index, str) and row_index.isdigit():
+            row_number = int(row_index) + header_offset
+        else:
+            row_number = display_idx + header_offset
+
+        month_value = value_map.get(month_col)
+        if _is_blank(month_value):
+            issues.append(
+                DataQualityIssue(
+                    row_number=row_number,
+                    column=str(month_col),
+                    issue_type="missing_month",
+                    message="年月が空欄です。",
+                    suggestion="YYYY-MM 形式（例: 2024-01）を入力してください。",
+                    original_value=month_value,
+                )
+            )
+        else:
+            try:
+                normalize_month_key(month_value)
+            except ValueError:
+                issues.append(
+                    DataQualityIssue(
+                        row_number=row_number,
+                        column=str(month_col),
+                        issue_type="invalid_month",
+                        message=f"年月の形式を認識できません: {month_value}",
+                        suggestion="YYYY-MM 形式（例: 2024-01）に修正してください。",
+                        original_value=month_value,
+                    )
+                )
+
+        product_value = value_map.get(product_col)
+        if _is_blank(product_value):
+            issues.append(
+                DataQualityIssue(
+                    row_number=row_number,
+                    column=str(product_col),
+                    issue_type="missing_product_name",
+                    message="商品名が空欄です。",
+                    suggestion="商品名を入力してください（例: 商品A）。",
+                    original_value=product_value,
+                )
+            )
+
+        if channel_col:
+            channel_value = value_map.get(channel_col)
+            if _is_blank(channel_value):
+                issues.append(
+                    DataQualityIssue(
+                        row_number=row_number,
+                        column=str(channel_col),
+                        issue_type="missing_channel",
+                        message="チャネルが空欄です。",
+                        suggestion="チャネルを入力してください（例: EC）。",
+                        suggested_value="全チャネル",
+                        original_value=channel_value,
+                    )
+                )
+
+        sales_value = value_map.get(sales_col)
+        if _is_blank(sales_value):
+            issues.append(
+                DataQualityIssue(
+                    row_number=row_number,
+                    column=str(sales_col),
+                    issue_type="missing_sales",
+                    message="売上額が未入力です。",
+                    suggestion="数値（例: 123456）を入力してください。",
+                    original_value=sales_value,
+                )
+            )
+            continue
+
+        numeric_value = _coerce_numeric(sales_value)
+        cleaned_candidate = None
+        cleaned_numeric = np.nan
+        if pd.isna(numeric_value) and isinstance(sales_value, str):
+            cleaned_candidate = (
+                sales_value.replace(",", "")
+                .replace("¥", "")
+                .replace("円", "")
+                .strip()
+            )
+            if cleaned_candidate != sales_value:
+                cleaned_numeric = _coerce_numeric(cleaned_candidate)
+
+        if pd.isna(numeric_value):
+            suggestion_text = "半角数字のみで入力してください。"
+            suggestion_value = None
+            if not pd.isna(cleaned_numeric):
+                suggestion_text = "カンマや通貨記号を除いた値に修正してください。"
+                suggestion_value = cleaned_numeric
+            issues.append(
+                DataQualityIssue(
+                    row_number=row_number,
+                    column=str(sales_col),
+                    issue_type="non_numeric_sales",
+                    message=f"売上額を数値に変換できません: {sales_value}",
+                    suggestion=suggestion_text,
+                    suggested_value=suggestion_value,
+                    original_value=sales_value,
+                )
+            )
+            continue
+
+        if numeric_value < 0:
+            issues.append(
+                DataQualityIssue(
+                    row_number=row_number,
+                    column=str(sales_col),
+                    issue_type="negative_sales",
+                    message=f"売上額がマイナスです ({numeric_value}).",
+                    suggestion="返品でない場合は正の値に修正してください。",
+                    suggested_value=abs(numeric_value),
+                    original_value=sales_value,
+                )
+            )
+
+    issues.sort(key=lambda issue: (issue.row_number, issue.column, issue.issue_type))
+    return issues
 
 
 # ---------- Parsing & Normalization ----------

--- a/tests/test_services_upload.py
+++ b/tests/test_services_upload.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from services import parse_uploaded_table
+from services import detect_data_quality_issues, parse_uploaded_table
 
 
 def test_parse_with_mapping_basic():
@@ -101,3 +101,99 @@ def test_parse_with_mapping_marks_missing_values():
     assert not feb_row.empty
     assert pd.isna(feb_row["sales_amount_jpy"].iloc[0])
     assert bool(feb_row["is_missing"].iloc[0])
+
+
+def test_detect_quality_issues_flags_missing_and_negative():
+    df = pd.DataFrame(
+        {
+            "Month": ["2024-01", None, "2024/03/01"],
+            "Channel": ["EC", "", "店舗"],
+            "Item": ["Alpha", "Beta", ""],
+            "Revenue": [1000, "abc", -200],
+        }
+    )
+
+    mapping = {
+        "month": "Month",
+        "channel": "Channel",
+        "product_name": "Item",
+        "sales": "Revenue",
+        "product_code": None,
+    }
+
+    issues = detect_data_quality_issues(df, mapping)
+
+    assert len(issues) == 5
+
+    missing_month_issue = next(
+        issue for issue in issues if issue.issue_type == "missing_month"
+    )
+    assert missing_month_issue.row_number == 3
+
+    non_numeric_issue = next(
+        issue for issue in issues if issue.issue_type == "non_numeric_sales"
+    )
+    assert "abc" in non_numeric_issue.message
+    assert non_numeric_issue.row_number == 3
+
+    negative_issue = next(
+        issue for issue in issues if issue.issue_type == "negative_sales"
+    )
+    assert negative_issue.row_number == 4
+    assert negative_issue.suggested_value == 200
+
+
+def test_detect_quality_issues_suggests_clean_numeric_and_invalid_month():
+    df = pd.DataFrame(
+        {
+            "Month": ["2024-13", "2024-02"],
+            "Channel": ["EC", "店舗"],
+            "Item": ["Alpha", "Beta"],
+            "Revenue": ["1,234", 5000],
+        }
+    )
+
+    mapping = {
+        "month": "Month",
+        "channel": "Channel",
+        "product_name": "Item",
+        "sales": "Revenue",
+        "product_code": None,
+    }
+
+    issues = detect_data_quality_issues(df, mapping)
+
+    assert len(issues) == 2
+
+    invalid_month_issue = next(
+        issue for issue in issues if issue.issue_type == "invalid_month"
+    )
+    assert invalid_month_issue.row_number == 2
+
+    numeric_issue = next(
+        issue for issue in issues if issue.issue_type == "non_numeric_sales"
+    )
+    assert numeric_issue.suggested_value == 1234
+    assert "カンマ" in numeric_issue.suggestion
+
+
+def test_detect_quality_issues_returns_empty_when_mapping_incomplete():
+    df = pd.DataFrame(
+        {
+            "Month": ["2024-01"],
+            "Item": ["Alpha"],
+            "Revenue": [1000],
+        }
+    )
+
+    mapping = {
+        "month": "Month",
+        "channel": None,
+        "product_name": "Item",
+        "sales": None,
+        "product_code": None,
+    }
+
+    issues = detect_data_quality_issues(df, mapping)
+
+    assert issues == []


### PR DESCRIPTION
## Summary
- add a `DataQualityIssue` dataclass and `detect_data_quality_issues` helper to flag missing, malformed, or negative records during upload
- surface the quality alerts on the upload screen with row numbers, suggested fixes, and a post-import summary banner
- cover the new logic with unit tests that exercise missing values, non-numeric inputs, and invalid months

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d24e0aaa8c832386e48bbe21a5705a