### PR TITLE
Add segment filters and drilldown analysis

### DIFF
--- a/sample_data/generate.py
+++ b/sample_data/generate.py
@@ -12,6 +12,7 @@ RNG = np.random.default_rng(0)
 
 CHANNELS = ["Online", "Store", "Wholesale"]
 CATEGORIES = ["A", "B", "C"]
+REGIONS = ["Kanto", "Kansai", "Chubu", "Kyushu"]
 
 
 def generate_transactions(months: int = 36, n_sku: int = 200) -> pd.DataFrame:
@@ -21,6 +22,7 @@ def generate_transactions(months: int = 36, n_sku: int = 200) -> pd.DataFrame:
         for sku in range(n_sku):
             channel = RNG.choice(CHANNELS)
             category = RNG.choice(CATEGORIES)
+            region = RNG.choice(REGIONS)
             price = RNG.integers(100, 500)
             qty = RNG.poisson(5)
             if RNG.random() < 0.02:
@@ -34,6 +36,7 @@ def generate_transactions(months: int = 36, n_sku: int = 200) -> pd.DataFrame:
                     "product_code": f"SKU{sku:04d}",
                     "product_name": f"商品{sku:04d}",
                     "category": category,
+                    "region": region,
                     "qty": qty,
                     "unit_price": price,
                     "revenue": revenue,

--- a/tests/test_services_upload.py
+++ b/tests/test_services_upload.py
@@ -23,14 +23,24 @@ def test_parse_with_mapping_basic():
 
     result = parse_uploaded_table(df, column_mapping=mapping)
 
-    assert set(result.columns) == {
+    expected_cols = {
         "product_code",
         "product_name",
+        "base_product_name",
+        "channel",
+        "category",
+        "customer_segment",
+        "region",
         "month",
         "sales_amount_jpy",
         "is_missing",
     }
+    assert expected_cols.issubset(set(result.columns))
     assert len(result) == 3
+
+    assert set(result["category"].unique()) == {"未分類"}
+    assert set(result["customer_segment"].unique()) == {"全顧客"}
+    assert set(result["region"].unique()) == {"全地域"}
 
     jan_ec = result[(result["product_name"] == "Alpha｜EC") & (result["month"] == "2024-01")]
     assert not jan_ec.empty
@@ -69,6 +79,7 @@ def test_parse_with_mapping_and_product_code_deduplication():
 
     assert sorted(result["product_code"].unique()) == ["SKU1｜EC", "SKU1｜店舗"]
     assert set(result["product_name"].unique()) == {"商品A｜EC", "商品A｜店舗"}
+    assert set(result["channel"].unique()) == {"EC", "店舗"}
     assert result["sales_amount_jpy"].sum() == 350
 
 


### PR DESCRIPTION
## Summary
- retain channel, category, customer segment, and region metadata through the ingestion pipeline so downstream metrics remain aware of each segment
- expose dashboard filters plus segment comparison tabs and a treemap drilldown to explore profitability and growth by channel, category, and major customers
- extend the sample transaction generator and tests to cover the new dimensions

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d25bb01af8832384a2f5244dfddc65