### PR TITLE
Remove manual month/channel mapping from data upload

### DIFF
--- a/services.py
+++ b/services.py
@@ -130,7 +130,7 @@ def _parse_with_mapping(
 ) -> pd.DataFrame:
     """Normalize a long-form table using an explicit column mapping."""
 
-    required_keys = ["month", "channel", "product_name", "sales"]
+    required_keys = ["month", "product_name", "sales"]
     missing_required = [k for k in required_keys if not mapping.get(k)]
     if missing_required:
         raise ValueError(

--- a/tests/test_services_upload.py
+++ b/tests/test_services_upload.py
@@ -112,3 +112,25 @@ def test_parse_with_mapping_marks_missing_values():
     assert not feb_row.empty
     assert pd.isna(feb_row["sales_amount_jpy"].iloc[0])
     assert bool(feb_row["is_missing"].iloc[0])
+
+
+def test_parse_with_mapping_without_channel_column():
+    df = pd.DataFrame(
+        {
+            "年月": ["2024-01", "2024-02"],
+            "商品名": ["Gamma", "Gamma"],
+            "売上額": [500, 600],
+        }
+    )
+
+    mapping = {
+        "month": "年月",
+        "product_name": "商品名",
+        "sales": "売上額",
+        "product_code": None,
+    }
+
+    result = parse_uploaded_table(df, column_mapping=mapping)
+
+    assert set(result["channel"].unique()) == {"全チャネル"}
+    assert result["sales_amount_jpy"].sum() == 1100


### PR DESCRIPTION
## Summary
- hide the month and channel mapping inputs on the data upload page, update the helper copy/template, and rely on auto-detection for those columns
- surface an error when required hidden columns are not detected while keeping the rest of the upload workflow intact
- allow parsing without an explicit channel mapping and add a regression test for the new behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d26ad158448323ad73cabb57b99b83